### PR TITLE
feat: add support for float32

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,17 +77,18 @@ releases. They are currently compatible with:
 ## Data Types
 Cloud Spanner supports the following data types in combination with `gorm`.
 
-| Cloud Spanner Type       | gorm / go type             |
-|--------------------------|----------------------------|
-| bool                     | bool, sql.NullBool         |
-| int64                    | uint, int64, sql.NullInt64 |
-| string                   | string, sql.NullString     |
-| json                     | string, sql.NullString     |
-| float64                  | float64, sql.NullFloat64   |
-| numeric                  | decimal.NullDecimal        |
-| timestamp with time zone | time.Time, sql.NullTime    |
-| date                     | datatypes.Date             |
-| bytes                    | []byte                     |
+| Cloud Spanner Type       | gorm / go type               |
+|--------------------------|------------------------------|
+| bool                     | bool, sql.NullBool           |
+| int64                    | uint, int64, sql.NullInt64   |
+| string                   | string, sql.NullString       |
+| json                     | string, sql.NullString       |
+| float64                  | float64, sql.NullFloat64     |
+| float32                  | float32, spanner.NullFloat32 |
+| numeric                  | decimal.NullDecimal          |
+| timestamp with time zone | time.Time, sql.NullTime      |
+| date                     | datatypes.Date               |
+| bytes                    | []byte                       |
 
 
 ## Limitations

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -44,6 +44,7 @@ type singer struct {
 type album struct {
 	gorm.Model
 	Title    string
+	Rating   float32
 	SingerID uint
 	Singer   *singer
 }
@@ -105,7 +106,7 @@ func TestMigrate(t *testing.T) {
 	}
 	if g, w := request.GetStatements()[4],
 		"CREATE TABLE `albums` (`id` INT64 DEFAULT (GET_NEXT_SEQUENCE_VALUE(Sequence albums_seq)),`created_at` TIMESTAMP,`updated_at` TIMESTAMP,`deleted_at` TIMESTAMP,"+
-			"`title` STRING(MAX),`singer_id` INT64,"+
+			"`title` STRING(MAX),`rating` FLOAT32,`singer_id` INT64,"+
 			"CONSTRAINT `fk_albums_singer` FOREIGN KEY (`singer_id`) REFERENCES `singers`(`id`)) "+
 			"PRIMARY KEY (`id`)"; g != w {
 		t.Fatalf("create albums statement text mismatch\n Got: %s\nWant: %s", g, w)

--- a/spanner.go
+++ b/spanner.go
@@ -200,6 +200,9 @@ func (dialector Dialector) DataTypeOf(field *schema.Field) string {
 	case schema.Int, schema.Uint:
 		return "INT64"
 	case schema.Float:
+		if field.Size == 32 {
+			return "FLOAT32"
+		}
 		return "FLOAT64"
 	case schema.String:
 		var size string

--- a/spanner_test.go
+++ b/spanner_test.go
@@ -15,11 +15,13 @@
 package gorm
 
 import (
+	"reflect"
+	"strconv"
+	"testing"
+
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/googleapis/go-sql-spanner/testutil"
 	"google.golang.org/protobuf/types/known/structpb"
-	"strconv"
-	"testing"
 )
 
 type singerWithCommitTimestamp struct {
@@ -27,6 +29,7 @@ type singerWithCommitTimestamp struct {
 	FirstName   string
 	LastName    string
 	LastUpdated CommitTimestamp
+	Rating      float32
 }
 
 func (singerWithCommitTimestamp) TableName() string {
@@ -41,12 +44,37 @@ func TestCommitTimestamp(t *testing.T) {
 		FirstName: "First",
 		LastName:  "Last",
 	}
-	_ = putSingerResult(server, "INSERT INTO `singers` (`first_name`,`last_name`,`last_updated`) VALUES (@p1,@p2,PENDING_COMMIT_TIMESTAMP()) THEN RETURN `id`", s)
+	_ = putSingerResult(server, "INSERT INTO `singers` (`first_name`,`last_name`,`last_updated`,`rating`) VALUES (@p1,@p2,PENDING_COMMIT_TIMESTAMP(),@p3) THEN RETURN `id`", s)
 	if err := db.Create(&s).Error; err != nil {
 		t.Fatalf("failed to create singer: %v", err)
 	}
 	if s.LastUpdated.Timestamp.Valid {
 		t.Fatalf("unexpected commit timestamp returned from insert")
+	}
+}
+
+func TestFloat32(t *testing.T) {
+	db, server, teardown := setupTestGormConnection(t)
+	defer teardown()
+
+	s := singerWithCommitTimestamp{
+		FirstName: "First",
+		LastName:  "Last",
+		Rating:    float32(3.14),
+	}
+	_ = putSingerResult(server, "INSERT INTO `singers` (`first_name`,`last_name`,`last_updated`,`rating`) VALUES (@p1,@p2,PENDING_COMMIT_TIMESTAMP(),@p3) THEN RETURN `id`", s)
+	if err := db.Create(&s).Error; err != nil {
+		t.Fatalf("failed to create singer: %v", err)
+	}
+	req := getLastSqlRequest(server)
+	if g, w := len(req.Params.Fields), 3; g != w {
+		t.Errorf("param value mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if g, w := len(req.Params.Fields), 3; g != w {
+		t.Errorf("param value mismatch\n Got: %v\nWant: %v", g, w)
+	}
+	if g, w := req.Params.Fields["p3"].GetNumberValue(), float64(float32(3.14)); g != w {
+		t.Errorf("rating value mismatch\n Got: %v\nWant: %v", g, w)
 	}
 }
 
@@ -68,4 +96,41 @@ func putSingerResult(server *testutil.MockedSpannerInMemTestServer, sql string, 
 			},
 		},
 	})
+}
+
+func getLastSql(server *testutil.MockedSpannerInMemTestServer) string {
+	return getLastSqlRequest(server).Sql
+}
+
+func getLastSqlRequest(server *testutil.MockedSpannerInMemTestServer) *spannerpb.ExecuteSqlRequest {
+	reqs := drainRequestsFromServer(server.TestSpanner)
+	execReqs := requestsOfType(reqs, reflect.TypeOf(&spannerpb.ExecuteSqlRequest{}))
+	if len(execReqs) > 0 {
+		return execReqs[len(execReqs)-1].(*spannerpb.ExecuteSqlRequest)
+	}
+	return &spannerpb.ExecuteSqlRequest{}
+}
+
+func requestsOfType(requests []interface{}, t reflect.Type) []interface{} {
+	res := make([]interface{}, 0)
+	for _, req := range requests {
+		if reflect.TypeOf(req) == t {
+			res = append(res, req)
+		}
+	}
+	return res
+}
+
+func drainRequestsFromServer(server testutil.InMemSpannerServer) []interface{} {
+	var reqs []interface{}
+loop:
+	for {
+		select {
+		case req := <-server.ReceivedRequests():
+			reqs = append(reqs, req)
+		default:
+			break loop
+		}
+	}
+	return reqs
 }

--- a/testutil/models.go
+++ b/testutil/models.go
@@ -16,8 +16,9 @@ package testutil
 
 import (
 	"database/sql"
-	"gorm.io/gorm"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // User has one `Account` (has one), many `Pets` (has many) and `Toys` (has many - polymorphic)
@@ -78,7 +79,7 @@ type Coupon struct {
 	ID               int              `gorm:"primarykey"`
 	AppliesToProduct []*CouponProduct `gorm:"foreignKey:CouponId;constraint:OnDelete:CASCADE"`
 	AmountOff        int64            `gorm:"column:amount_off"`
-	PercentOff       float32          `gorm:"column:percent_off"`
+	PercentOff       float64          `gorm:"column:percent_off"`
 }
 
 type CouponProduct struct {


### PR DESCRIPTION
Adds support for using `float32` with gorm.

__NOTE__: If you have any fields that use `float32` as its Go data type, then running a migration for that field will now produce a `FLOAT32` column on Spanner instead of a `FLOAT64` column. To prevent this, you need to either change the type of the field to `float64`, or add a field tag annotation to the field to pin the data type to `FLOAT64`. (https://gorm.io/docs/models.html#Fields-Tags)
