### PR TITLE
test: fix cleanup instance RPC filter

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -112,7 +112,7 @@ func initTestInstance(config string) (cleanup func(), err error) {
 		// Also delete any other stale test instance.
 		instances := instanceAdmin.ListInstances(ctx, &instancepb.ListInstancesRequest{
 			Parent: fmt.Sprintf("projects/%s", projectId),
-			Filter: "label.gormtestinstance:*",
+			Filter: "labels.gormtestinstance:true",
 		})
 		for {
 			instance, err := instances.Next()


### PR DESCRIPTION
This will fix issue in running samples test cleanup

<img width="1311" alt="Screenshot 2024-05-30 at 12 29 37 PM" src="https://github.com/googleapis/go-gorm-spanner/assets/18293335/0afad159-db2c-45c7-afb2-5e21e4b5dda6">
