### PR TITLE
build: bump minimum go version for tests to 1.20

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Go only supports the three last major versions. That means that Go 1.19 is no longer supported. This removes Go 1.19 from the set of Go versions that is used for testing, and adds 1.20, 1.21, and 1.22.