### PR TITLE
feat: support dry-run mode for auto-migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ Cloud Spanner supports the following data types in combination with `gorm`.
 | bytes                    | []byte                       |
 
 
+## AutoMigrate Dry Run
+The Spanner `gorm` dialect supports dry-runs for auto-migration. Use this to get the
+DDL statements that would be generated and executed by auto-migration. You can manually
+verify and modify these statements to optimize your data model.
+
+Example:
+
+```go
+tables := []interface{}{&singer{}, &album{}}
+
+// Unwrap the underlying SpannerMigrator interface. This interface supports
+// the `AutoMigrateDryRun` method, which does not actually execute the
+// generated statements, and instead just returns these as an array.
+m := db.Migrator()
+migrator, ok := m.(spannergorm.SpannerMigrator)
+if !ok {
+    return fmt.Errorf("unexpected migrator type: %v", m)
+}
+statements, err := migrator.AutoMigrateDryRun(tables...)
+```
+
 ## Limitations
 The Cloud Spanner `gorm` dialect has the following known limitations:
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/longrunning v0.6.2
 	cloud.google.com/go/spanner v1.73.0
 	github.com/golang/protobuf v1.5.4
+	github.com/google/go-cmp v0.6.0
 	github.com/googleapis/go-sql-spanner v1.8.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
Adds a dry-run mode for AutoMigrate for Spanner databases. The output of a dry-run can be inspected and manually modified to include specific Spanner features, such as interleaved tables or row deletion policies.