### PR TITLE
docs: add test to verify that FOR UPDATE clauses can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,16 +113,15 @@ statements, err := migrator.AutoMigrateDryRun(tables...)
 ```
 
 ## Limitations
-The Cloud Spanner `gorm` dialect has the following known limitations:
+The Spanner `gorm` dialect has the following known limitations:
 
-| Limitation                                                                                     | Workaround                                                                                                                                                                                                                     |
-|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Nested transactions                                                                            | Nested transactions and savepoints are not supported. It is therefore recommended to set the configuration option `DisableNestedTransaction: true,`                                                                            |
-| Locking                                                                                        | Lock clauses (e.g. `clause.Locking{Strength: "UPDATE"}`) are not supported. These are generally speaking also not required, as the default isolation level that is used by Cloud Spanner is serializable.                      |
-| [gorm.Automigrate](https://gorm.io/docs/migration.html#Auto-Migration) with interleaved tables | [Interleaved tables](samples/sample_application) are supported by the Cloud Spanner `gorm` dialect, but Auto-Migration does not support interleaved tables. It is therefore recommended to create interleaved tables manually. |
-| [Cloud Spanner stale reads](https://cloud.google.com/spanner/docs/reads#go)                    | Stale reads are not supported by gorm.                                                                                                                                                                                         |    
+| Limitation                                                                                     | Workaround                                                                                                                                                                                                               |
+|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Nested transactions                                                                            | Nested transactions and savepoints are not supported. It is therefore recommended to set the configuration option `DisableNestedTransaction: true,`                                                                      |
+| [gorm.Automigrate](https://gorm.io/docs/migration.html#Auto-Migration) with interleaved tables | [Interleaved tables](samples/sample_application) are supported by the Spanner `gorm` dialect, but Auto-Migration does not support interleaved tables. It is therefore recommended to create interleaved tables manually. |
+| [Spanner stale reads](https://cloud.google.com/spanner/docs/reads#go)                          | Stale reads are not supported by gorm.                                                                                                                                                                                   |
 
-For the complete list of the limitations, see the [Cloud Spanner GORM limitations](https://github.com/googleapis/go-gorm-spanner/blob/main/docs/limitations.md).
+For the complete list of the limitations, see the [Spanner GORM limitations](/docs/limitations.md).
 
 ### Nested Transactions
 `gorm` uses savepoints for nested transactions. Savepoints are currently not supported by Cloud Spanner. Nested

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -5,7 +5,6 @@ The following limitations are currently known:
 |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | OnConflict             | OnConflict clauses are not supported                                                                                                                                                                      |
 | Nested transactions    | Nested transactions and savepoints are not supported. It is therefore recommended to set the configuration option `DisableNestedTransaction: true,`                                                       |
-| Locking                | Lock clauses (e.g. `clause.Locking{Strength: "UPDATE"}`) are not supported. These are generally speaking also not required, as the default isolation level that is used by Cloud Spanner is serializable. |
 | Auto-save associations | Auto saved associations are not supported, as these will automatically use an OnConflict clause                                                                                                           |
 | Session Labelling      | Session labelling is not supported.                                                                                                                                                                       |
 | Request Priority       | Request priority is not supported.                                                                                                                                                                        |
@@ -66,7 +65,3 @@ db.Create(&blog)
 ### Nested Transactions
 `gorm` uses savepoints for nested transactions. Savepoints are currently not supported by Cloud Spanner. Nested
 transactions can therefore not be used with GORM.
-
-### Locking
-Locking clauses, like `clause.Locking{Strength: "UPDATE"}`, are not supported. These are generally speaking also not
-required, as Cloud Spanner uses isolation level `serializable` for read/write transactions.


### PR DESCRIPTION
Spanner now supports FOR UPDATE clauses in SELECT statements. This change adds a test that verifies that gorm can be used to generate SELECT statements with FOR UPDATE clauses.

See also https://cloud.google.com/spanner/docs/release-notes#January_27_2025