### PR TITLE
chore: align supported Go versions with Go policy

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -6,7 +6,7 @@ jobs:
   samples:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -94,11 +94,8 @@ $ export SPANNER_EMULATOR_HOST=localhost:9010
 
 ## [Go Versions Supported](#supported-versions)
 
-Our libraries are compatible with at least the three most recent, major Go
-releases. They are currently compatible with:
-
-- Go 1.23
-- Go 1.22
+The Spanner gorm dialect follows the [Go release policy](https://go.dev/doc/devel/release)
+and supports the two latest major Go versions.
 
 ## Data Types
 Spanner supports the following data types in combination with `gorm`.


### PR DESCRIPTION
Align the supported Go versions with the support policy of Go itself, and the support policy of the Spanner database/sql driver. That is: The two last major versions of Go are supported.