### PR TITLE
chore: replace old spanner teams with spanner-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/api-spanner-go
+*     @googleapis/spanner-team


### PR DESCRIPTION
This PR replaces old Spanner and platform teams with the new spanner-team and cloud-sdk-platform-team. b/478003109