### PR TITLE
feat(gorm): implement Translate for Spanner gRPC errors

### DIFF
--- a/error_translator.go
+++ b/error_translator.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gorm
+
+import (
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+	"gorm.io/gorm"
+)
+
+var errCodes = map[codes.Code]error{
+	codes.AlreadyExists: gorm.ErrDuplicatedKey,
+}
+
+func (dialector Dialector) Translate(err error) error {
+	if err, ok := errCodes[spanner.ErrCode(err)]; ok {
+		return err
+	}
+	return err
+}

--- a/error_translator_test.go
+++ b/error_translator_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gorm
 
 import (

--- a/error_translator_test.go
+++ b/error_translator_test.go
@@ -1,0 +1,50 @@
+package gorm
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+var testErrors = map[codes.Code]error{
+	codes.AlreadyExists:   spanner.ToSpannerError(status.Errorf(codes.AlreadyExists, "already exists")),
+	codes.InvalidArgument: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "invalid argument")),
+	codes.Unknown:         errors.New("random error"),
+}
+
+func TestErrorTranslator(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "AlreadyExists returns gorm.ErrDuplicatedKey",
+			err:  testErrors[codes.AlreadyExists],
+			want: gorm.ErrDuplicatedKey,
+		},
+		{
+			name: "InvalidArgument returns original error",
+			err:  testErrors[codes.InvalidArgument],
+			want: testErrors[codes.InvalidArgument],
+		},
+		{
+			name: "Random error returns original error",
+			err:  testErrors[codes.Unknown],
+			want: testErrors[codes.Unknown],
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dialector := Dialector{}
+			got := dialector.Translate(tt.err)
+			if got != tt.want {
+				t.Errorf("translate error mismatch:\n Got: %v\nWant: %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/postgresql/error_translator.go
+++ b/postgresql/error_translator.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spannerpg
+
+import (
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+	"gorm.io/gorm"
+)
+
+var errCodes = map[codes.Code]error{
+	codes.AlreadyExists: gorm.ErrDuplicatedKey,
+}
+
+func (dialector Dialector) Translate(err error) error {
+	if err, ok := errCodes[spanner.ErrCode(err)]; ok {
+		return err
+	}
+	return err
+}

--- a/postgresql/error_translator_test.go
+++ b/postgresql/error_translator_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package spannerpg
 
 import (

--- a/postgresql/error_translator_test.go
+++ b/postgresql/error_translator_test.go
@@ -1,0 +1,50 @@
+package spannerpg
+
+import (
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+var testErrors = map[codes.Code]error{
+	codes.AlreadyExists:   spanner.ToSpannerError(status.Errorf(codes.AlreadyExists, "already exists")),
+	codes.InvalidArgument: spanner.ToSpannerError(status.Errorf(codes.InvalidArgument, "invalid argument")),
+	codes.Unknown:         errors.New("random error"),
+}
+
+func TestErrorTranslator(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "AlreadyExists returns gorm.ErrDuplicatedKey",
+			err:  testErrors[codes.AlreadyExists],
+			want: gorm.ErrDuplicatedKey,
+		},
+		{
+			name: "InvalidArgument returns original error",
+			err:  testErrors[codes.InvalidArgument],
+			want: testErrors[codes.InvalidArgument],
+		},
+		{
+			name: "Random error returns original error",
+			err:  testErrors[codes.Unknown],
+			want: testErrors[codes.Unknown],
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dialector := Dialector{}
+			got := dialector.Translate(tt.err)
+			if got != tt.want {
+				t.Errorf("translate error mismatch:\n Got: %v\nWant: %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implementation of https://github.com/googleapis/go-gorm-spanner/issues/243

Only added the mapping of `AlreadyExists` to `gorm.ErrDuplicatedKey`. There is a way to also add mappings for other error types but requires evaluating the desc of the returned errors from spanner. Which IMO could become fragile since Google states desc could be changed at anytime... (example below)

```go
switch code {
    case codes.FailedPrecondition:
        if strings.Contains(msg, "Foreign key constraint") {
            return gorm.ErrForeignKeyViolated
        }
    case codes.OutOfRange:
        if strings.Contains(msg, "Check constraint") {
            return gorm.ErrCheckConstraintViolated
        }
    case codes.InvalidArgument:
        if strings.Contains(msg, "Unrecognized name") {
            return gorm.ErrInvalidField
        }
    }
```  